### PR TITLE
Support custom elevenlabs api key

### DIFF
--- a/src/actions/speak/connector/elevenlabs_tts.py
+++ b/src/actions/speak/connector/elevenlabs_tts.py
@@ -15,8 +15,11 @@ class SpeakRos2Connector(ActionConnector[SpeakInput]):
         microphone_name = getattr(self.config, "microphone_name", None)
         speaker_name = getattr(self.config, "speaker_name", None)
 
-        # Eleven Labs TTS configuration
+        # OM API key
         api_key = getattr(self.config, "api_key", None)
+
+        # Eleven Labs TTS configuration
+        elevenlabs_api_key = getattr(self.config, "elevenlabs_api_key", None)
         voice_id = getattr(self.config, "voice_id", "JBFqnCBsd6RMkjVDRZzb")
         model_id = getattr(self.config, "model_id", "eleven_flash_v2_5")
         output_format = getattr(self.config, "output_format", "mp3_44100_128")
@@ -30,6 +33,7 @@ class SpeakRos2Connector(ActionConnector[SpeakInput]):
         self.tts = ElevenLabsTTSProvider(
             url="https://api.openmind.org/api/core/elevenlabs/tts",
             api_key=api_key,
+            elevenlabs_api_key=elevenlabs_api_key,
             device_id=speaker_device_id,
             speaker_name=speaker_name,
             voice_id=voice_id,

--- a/src/actions/speak/connector/riva_tts.py
+++ b/src/actions/speak/connector/riva_tts.py
@@ -15,7 +15,7 @@ class SpeakRos2Connector(ActionConnector[SpeakInput]):
         microphone_name = getattr(self.config, "microphone_name", None)
         speaker_name = getattr(self.config, "speaker_name", None)
 
-        # Riva TTS configuration
+        # OM API key
         api_key = getattr(self.config, "api_key", None)
 
         # Initialize ASR and TTS providers

--- a/src/providers/elevenlabs_tts_provider.py
+++ b/src/providers/elevenlabs_tts_provider.py
@@ -91,6 +91,7 @@ class ElevenLabsTTSProvider:
         self,
         url: str,
         api_key: Optional[str] = None,
+        elevenlabs_api_key: Optional[str] = None,
         device_id: Optional[int] = None,
         speaker_name: Optional[str] = None,
         voice_id: Optional[str] = "JBFqnCBsd6RMkjVDRZzb",
@@ -101,6 +102,7 @@ class ElevenLabsTTSProvider:
         Initialize the TTS provider with given URL.
         """
         self.api_key: str = api_key
+        self.elevenlabs_api_key: str = elevenlabs_api_key
 
         # Initialize TTS provider
         self.running: bool = False
@@ -138,12 +140,18 @@ class ElevenLabsTTSProvider:
             Text to be converted to speech
         """
         logging.info(f"audio_stream: {text}")
+        elevenlabs_api_key = (
+            {"elevenlabs_api_key": self.elevenlabs_api_key}
+            if self.elevenlabs_api_key
+            else {}
+        )
         self._audio_stream.add_request(
             {
                 "text": text,
                 "voice_id": self._voice_id,
                 "model_id": self._model_id,
                 "output_format": self._output_format,
+                **elevenlabs_api_key,
             }
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1962,7 +1962,7 @@ requires-dist = [
     { name = "hid" },
     { name = "jinja2", specifier = ">=3.1.3" },
     { name = "numpy" },
-    { name = "om1-modules", git = "https://github.com/OpenmindAGI/om1-modules.git?rev=4d0c6c98319b1d655d36cb25a7e3ae8ad2dac826#4d0c6c98319b1d655d36cb25a7e3ae8ad2dac826" },
+    { name = "om1-modules", git = "https://github.com/OpenmindAGI/om1-modules.git?rev=a049c4c0b8174a56b82da5e17fa725ddde79805a#a049c4c0b8174a56b82da5e17fa725ddde79805a" },
     { name = "openai", specifier = ">=1.59.5" },
     { name = "opencv-python" },
     { name = "pillow", specifier = ">=11.1.0" },
@@ -1993,7 +1993,7 @@ dev = [
 [[package]]
 name = "om1-modules"
 version = "0.1.0"
-source = { git = "https://github.com/OpenmindAGI/om1-modules.git?rev=4d0c6c98319b1d655d36cb25a7e3ae8ad2dac826#4d0c6c98319b1d655d36cb25a7e3ae8ad2dac826" }
+source = { git = "https://github.com/OpenmindAGI/om1-modules.git?rev=a049c4c0b8174a56b82da5e17fa725ddde79805a#a049c4c0b8174a56b82da5e17fa725ddde79805a" }
 dependencies = [
     { name = "numpy" },
     { name = "opencv-python" },


### PR DESCRIPTION
Users can provide their own ElevenLabs API key through the elevenlabs_api_key field. However, this method is not recommended, as your API key will be exposed in our backend, even though we do not store any API keys.