### PR TITLE
fix most actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ uv venv
 
 Note: If you don't have the Rust python package manager `uv`, please install it via `brew install uv` (for Mac) and `curl -LsSf https://astral.sh/uv/install.sh | sh` for Linux.
 
-Note: If your system doesn't have `portaudio`, you can install it via `brew install portaudio` (Mac) or `sudo apt-get install libasound-dev` (Linux).
+Note: Depending on your system, you may also need other packages, such as `portaudio` and `ffmpeg`. You can install them via `brew install portaudio` (Mac) or `sudo apt-get install libasound-dev` (Linux), and `brew install ffmpeg` or similar commands).
 
 2. Set configuration variables
 

--- a/src/actions/face/connector/ros2.py
+++ b/src/actions/face/connector/ros2.py
@@ -1,10 +1,14 @@
 import logging
 
-from actions.base import ActionConnector
+from actions.base import ActionConfig, ActionConnector
 from actions.face.interface import FaceInput
 
 
 class FaceRos2Connector(ActionConnector[FaceInput]):
+
+    def __init__(self, config: ActionConfig):
+        super().__init__(config)
+
     async def connect(self, output_interface: FaceInput) -> None:
         # define/clarify the datatype
         new_msg = {"face": ""}

--- a/src/actions/move/connector/ros2.py
+++ b/src/actions/move/connector/ros2.py
@@ -1,11 +1,14 @@
 import logging
 import time
 
-from actions.base import ActionConnector
+from actions.base import ActionConfig, ActionConnector
 from actions.move.interface import MoveInput
 
 
 class MoveRos2Connector(ActionConnector[MoveInput]):
+
+    def __init__(self, config: ActionConfig):
+        super().__init__(config)
 
     async def connect(self, output_interface: MoveInput) -> None:
 

--- a/src/actions/move_safe/connector/ros2.py
+++ b/src/actions/move_safe/connector/ros2.py
@@ -4,15 +4,16 @@ import time
 
 import hid
 
-from actions.base import ActionConnector
+from actions.base import ActionConfig, ActionConnector
 from actions.move_safe.interface import MoveInput
 from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
 
 
 class MoveRos2Connector(ActionConnector[MoveInput]):
 
-    def __init__(self):
-        # pygame.init()
+    def __init__(self, config: ActionConfig):
+        super().__init__(config)
+
         self.joysticks = []
 
         self.vendor_id = ""

--- a/src/actions/move_serial_arduino/connector/serial_arduino.py
+++ b/src/actions/move_serial_arduino/connector/serial_arduino.py
@@ -3,7 +3,7 @@ import time
 
 import serial
 
-from actions.base import ActionConnector
+from actions.base import ActionConfig, ActionConnector
 from actions.move.interface import MoveInput
 
 """
@@ -13,8 +13,8 @@ This only works if you actually have a serial port connected to your computer, s
 
 class MoveSerialConnector(ActionConnector[MoveInput]):
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, config: ActionConfig):
+        super().__init__(config)
 
         # Open the serial port
         self.port = (

--- a/src/actions/speak/connector/ros2.py
+++ b/src/actions/speak/connector/ros2.py
@@ -1,10 +1,14 @@
 import logging
 
-from actions.base import ActionConnector
+from actions.base import ActionConfig, ActionConnector
 from actions.speak.interface import SpeakInput
 
 
 class SpeakRos2Connector(ActionConnector[SpeakInput]):
+
+    def __init__(self, config: ActionConfig):
+        super().__init__(config)
+
     async def connect(self, output_interface: SpeakInput) -> None:
 
         new_msg = {"speak": output_interface.sentence}

--- a/src/actions/tweet/connector/twitterAPI.py
+++ b/src/actions/tweet/connector/twitterAPI.py
@@ -4,15 +4,16 @@ import warnings
 
 from dotenv import load_dotenv
 
-from actions.base import ActionConnector
+from actions.base import ActionConfig, ActionConnector
 from actions.tweet.interface import TweetInput
 
 
 class TweetAPIConnector(ActionConnector[TweetInput]):
     """Connector for Twitter API."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, config: ActionConfig):
+        super().__init__(config)
+
         load_dotenv()
 
         # Suppress tweepy warnings

--- a/uv.lock
+++ b/uv.lock
@@ -1962,7 +1962,7 @@ requires-dist = [
     { name = "hid" },
     { name = "jinja2", specifier = ">=3.1.3" },
     { name = "numpy" },
-    { name = "om1-modules", git = "https://github.com/OpenmindAGI/om1-modules.git?rev=4d0c6c98319b1d655d36cb25a7e3ae8ad2dac826#4d0c6c98319b1d655d36cb25a7e3ae8ad2dac826" },
+    { name = "om1-modules", git = "https://github.com/OpenmindAGI/om1-modules.git?rev=a049c4c0b8174a56b82da5e17fa725ddde79805a#a049c4c0b8174a56b82da5e17fa725ddde79805a" },
     { name = "openai", specifier = ">=1.59.5" },
     { name = "opencv-python" },
     { name = "pillow", specifier = ">=11.1.0" },
@@ -1993,7 +1993,7 @@ dev = [
 [[package]]
 name = "om1-modules"
 version = "0.1.0"
-source = { git = "https://github.com/OpenmindAGI/om1-modules.git?rev=4d0c6c98319b1d655d36cb25a7e3ae8ad2dac826#4d0c6c98319b1d655d36cb25a7e3ae8ad2dac826" }
+source = { git = "https://github.com/OpenmindAGI/om1-modules.git?rev=a049c4c0b8174a56b82da5e17fa725ddde79805a#a049c4c0b8174a56b82da5e17fa725ddde79805a" }
 dependencies = [
     { name = "numpy" },
     { name = "opencv-python" },


### PR DESCRIPTION
The transition to:

```
def __init__(self, config: ActionConfig):
        super().__init__(config)
```

broke most examples since the init now provides two variables, not just one. This resulted in:

```
MoveSerialConnector.__init__() takes 1 positional argument but 2 were given
```

type errors 