### PR TITLE
Support TTS cache

### DIFF
--- a/config/cache.json
+++ b/config/cache.json
@@ -1,0 +1,46 @@
+{
+  "hertz": 1,
+  "name": "spot_cache",
+  "cache": true,
+  "api_key": "openmind_free",
+  "system_prompt_base": "You are a smart, curious, and friendly dog. Your name is Spot. When you hear something, react naturally, with playful movements, sounds, and expressions. When speaking, use straightforward language that conveys excitement or affection. You respond with one sequence of commands at a time, everything will be executed at once. Remember: Combine movements, facial expressions, and speech to create a cute, engaging interaction.",
+  "system_governance": "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+  "system_prompt_examples": "Here are some examples of interactions you might encounter:\n\n1. If a person says 'Give me your paw!', you might:\n    Move: 'shake paw'\n    Speak: {{'sentence': 'Hello, let\\'s shake paws!'}}\n    Face: 'joy'\n\n2. If a person says 'Sit!' you might:\n    Move: 'sit'\n    Speak: {{'sentence': 'Ok, but I like running more'}}\n    Face: 'smile'\n\n3. If there\\'s no sound, go explore. You might:\n    Move: 'run'\n    Speak: {{'sentence': 'I\\'m going to go explore the room and meet more people.'}}\n    Face: 'think' \n Don't usually talk shake paws. Please say someting that makes sense and interaction will be more fun.",
+  "agent_inputs": [
+    {
+      "type": "GovernanceEthereum"
+    }
+  ],
+  "simulators": [
+    {
+      "type": "WebSim",
+      "config": {
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tick_rate": 100,
+        "auto_reconnect": true,
+        "debug_mode": false
+      }
+    }
+  ],
+  "cortex_llm": {
+    "type": "OpenAILLM"
+  },
+  "agent_actions": [
+    {
+      "name": "move",
+      "implementation": "passthrough",
+      "connector": "ros2"
+    },
+    {
+      "name": "speak",
+      "implementation": "passthrough",
+      "connector": "elevenlabs_tts"
+    },
+    {
+      "name": "face",
+      "implementation": "passthrough",
+      "connector": "ros2"
+    }
+  ]
+}

--- a/src/actions/speak/connector/elevenlabs_tts.py
+++ b/src/actions/speak/connector/elevenlabs_tts.py
@@ -24,14 +24,20 @@ class SpeakRos2Connector(ActionConnector[SpeakInput]):
         model_id = getattr(self.config, "model_id", "eleven_flash_v2_5")
         output_format = getattr(self.config, "output_format", "mp3_44100_128")
 
+        # Endpoint URLs
+        asr_url = getattr(self.config, "asr_url", "wss://api-asr.openmind.org")
+        tts_url = getattr(
+            self.config, "tts_url", "https://api.openmind.org/api/core/elevenlabs/tts"
+        )
+
         # Initialize ASR and TTS providers
         self.asr = ASRProvider(
-            ws_url="wss://api-asr.openmind.org",
+            ws_url=asr_url,
             device_id=microphone_device_id,
             microphone_name=microphone_name,
         )
         self.tts = ElevenLabsTTSProvider(
-            url="https://api.openmind.org/api/core/elevenlabs/tts",
+            url=tts_url,
             api_key=api_key,
             elevenlabs_api_key=elevenlabs_api_key,
             device_id=speaker_device_id,

--- a/src/actions/speak/connector/riva_tts.py
+++ b/src/actions/speak/connector/riva_tts.py
@@ -18,14 +18,20 @@ class SpeakRos2Connector(ActionConnector[SpeakInput]):
         # OM API key
         api_key = getattr(self.config, "api_key", None)
 
+        # Endpoint URLs
+        asr_url = getattr(self.config, "asr_url", "wss://api-asr.openmind.org")
+        tts_url = getattr(
+            self.config, "tts_url", "https://api.openmind.org/api/core/riva/tts"
+        )
+
         # Initialize ASR and TTS providers
         self.asr = ASRProvider(
-            ws_url="wss://api-asr.openmind.org",
+            ws_url=asr_url,
             device_id=microphone_device_id,
             microphone_name=microphone_name,
         )
         self.tts = RivaTTSProvider(
-            url="https://api.openmind.org/api/core/riva/tts",
+            url=tts_url,
             device_id=speaker_device_id,
             speaker_name=speaker_name,
             api_key=api_key,

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -22,11 +22,14 @@ class LLMConfig(BaseModel):
         Authentication key for the LLM service
     model : str, optional
         Name of the LLM model to use
+    uuid: str, optional
+        UUID for the process
     """
 
     base_url: T.Optional[str] = None
     api_key: T.Optional[str] = None
     model: T.Optional[str] = None
+    uuid: T.Optional[str] = None
 
 
 class LLM(T.Generic[R]):

--- a/src/llm/plugins/deepseek_llm.py
+++ b/src/llm/plugins/deepseek_llm.py
@@ -88,6 +88,7 @@ class DeepSeekLLM(LLM[R]):
                 ),
                 messages=messages,
                 response_format={"type": "json_object"},
+                extra_headers={"x-uuid": self._config.uuid},
             )
 
             message_content = parsed_response.choices[0].message.content

--- a/src/llm/plugins/gemini_llm.py
+++ b/src/llm/plugins/gemini_llm.py
@@ -85,6 +85,7 @@ class GeminiLLM(LLM[R]):
             ),
             messages=self._build_messages(prompt),
             response_format={"type": "json_object"},
+            extra_headers={"x-uuid": self._config.uuid},
         )
         return completion
 

--- a/src/llm/plugins/openai_llm.py
+++ b/src/llm/plugins/openai_llm.py
@@ -79,6 +79,7 @@ class OpenAILLM(LLM[R]):
                 ),
                 messages=[{"role": "user", "content": prompt}],
                 response_format=self._output_model,
+                extra_headers={"x-uuid": self._config.uuid},
             )
 
             message_content = parsed_response.choices[0].message.content

--- a/src/runtime/beamer.py
+++ b/src/runtime/beamer.py
@@ -1,0 +1,82 @@
+import logging
+from typing import Dict
+
+import requests
+
+
+def setup_beamer(api_key: str, uuid: str, raw_config: Dict) -> bool:
+    """
+    Setup the beamer for caching
+
+    Parameters
+    ----------
+    api_key : str
+        The API key for the beamer
+    uuid : str
+        The UUID for the beamer
+    raw_config : dict
+        The raw configuration
+
+    Returns
+    -------
+    bool
+        True if cache is enabled, False otherwise
+    """
+    cache = False
+    if raw_config.get("cache", False) and api_key is not None and api_key != "":
+        cache = send_beams_to_beamer(api_key, uuid, raw_config)
+
+    if "beamer_url" in raw_config:
+        del raw_config["beamer_url"]
+
+    return cache
+
+
+def send_beams_to_beamer(api_key: str, uuid: str, raw_config: Dict) -> bool:
+    """
+    Send beams to the beamer
+
+    Parameters
+    ----------
+    api_key : str
+        The API key for the beamer
+    uuid : str
+        The UUID for the beamer
+    raw_config : dict
+        The raw configuration
+
+    Returns
+    -------
+    bool
+        True if beams were sent successfully, False otherwise
+    """
+    beamer_url = raw_config.get(
+        "beamer_url", "https://api.openmind.org/api/core/beamer"
+    )
+    try:
+        response = requests.post(
+            beamer_url,
+            json=raw_config,
+            headers={
+                "x-api-key": api_key,
+                "Content-Type": "application/json",
+                "x-uuid": uuid,
+            },
+        )
+        if response.status_code == 200:
+            logging.info(
+                "Caching is enabled for TTS requests. Beams have been sent to the beamer. Please be mindful of potential privacy implications."
+            )
+            return True
+        else:
+            logging.error(
+                "Caching is enabled for TTS requests, but beams could not be sent to the beamer. Please check your configuration. error: %s",
+                response.text,
+            )
+            return False
+    except Exception as e:
+        logging.error(
+            "Caching is enabled for TTS requests, but beams could not be sent to the beamer. Please check your configuration. error: %s",
+            e,
+        )
+        return False

--- a/tests/runtime/test_beamer.py
+++ b/tests/runtime/test_beamer.py
@@ -1,0 +1,132 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from runtime.beamer import send_beams_to_beamer, setup_beamer
+
+API_KEY = "test-api-key"
+UUID = "test-uuid"
+BASE_CONFIG = {
+    "cache": True,
+    "beamer_url": "https://api.openmind.org/api/core/beamer",
+    "other_config": "value",
+}
+
+
+@pytest.fixture
+def mock_requests():
+    with patch("requests.post") as mock_post:
+        yield mock_post
+
+
+@pytest.fixture
+def mock_logging():
+    with patch("logging.info") as mock_info, patch("logging.error") as mock_error:
+        yield {"info": mock_info, "error": mock_error}
+
+
+def test_setup_beamer_with_cache_enabled(mock_requests, mock_logging):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_requests.return_value = mock_response
+    config = BASE_CONFIG.copy()
+
+    result = setup_beamer(API_KEY, UUID, config)
+
+    assert result is True
+    assert "beamer_url" not in config
+    mock_requests.assert_called_once_with(
+        BASE_CONFIG["beamer_url"],
+        json=config,
+        headers={
+            "x-api-key": API_KEY,
+            "Content-Type": "application/json",
+            "x-uuid": UUID,
+        },
+    )
+    mock_logging["info"].assert_called_once()
+
+
+def test_setup_beamer_with_cache_disabled():
+    config = BASE_CONFIG.copy()
+    config["cache"] = False
+
+    result = setup_beamer(API_KEY, UUID, config)
+
+    assert result is False
+    assert "beamer_url" not in config
+
+
+def test_setup_beamer_with_empty_api_key():
+    config = BASE_CONFIG.copy()
+
+    result = setup_beamer("", UUID, config)
+
+    assert result is False
+    assert "beamer_url" not in config
+
+
+def test_setup_beamer_with_none_api_key():
+    config = BASE_CONFIG.copy()
+
+    result = setup_beamer(None, UUID, config)
+
+    assert result is False
+    assert "beamer_url" not in config
+
+
+def test_send_beams_to_beamer_success(mock_requests, mock_logging):
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_requests.return_value = mock_response
+    config = BASE_CONFIG.copy()
+
+    result = send_beams_to_beamer(API_KEY, UUID, config)
+
+    assert result is True
+    mock_logging["info"].assert_called_once()
+
+
+def test_send_beams_to_beamer_failure(mock_requests, mock_logging):
+    mock_response = Mock()
+    mock_response.status_code = 400
+    mock_response.text = "Bad Request"
+    mock_requests.return_value = mock_response
+    config = BASE_CONFIG.copy()
+
+    result = send_beams_to_beamer(API_KEY, UUID, config)
+
+    assert result is False
+    mock_logging["error"].assert_called_once()
+
+
+def test_send_beams_to_beamer_exception(mock_requests, mock_logging):
+    mock_requests.side_effect = Exception("Connection error")
+    config = BASE_CONFIG.copy()
+
+    result = send_beams_to_beamer(API_KEY, UUID, config)
+
+    assert result is False
+    mock_logging["error"].assert_called_once()
+
+
+def test_send_beams_to_beamer_custom_url(mock_requests):
+    # Arrange
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_requests.return_value = mock_response
+    config = BASE_CONFIG.copy()
+    config["beamer_url"] = "https://custom.api.url/beamer"
+
+    result = send_beams_to_beamer(API_KEY, UUID, config)
+
+    assert result is True
+    mock_requests.assert_called_once_with(
+        "https://custom.api.url/beamer",
+        json=config,
+        headers={
+            "x-api-key": API_KEY,
+            "Content-Type": "application/json",
+            "x-uuid": UUID,
+        },
+    )


### PR DESCRIPTION
## Overview

Support TTS cache

## Changes

This PR introduces a new component called `beamer`. When `cache` is set to `true` in the `config.json` file, `beamer` will automatically share your configuration file with the OM backend. The OM backend will then use this configuration to determine the desired TTS voice settings.

Additionally, when you call the LLM endpoint, its response will be sent directly to the TTS endpoint, allowing it to be pre-fetched for when you make a request.

While this increases LLM response time by 0.1 - 0.15 seconds, it significantly reduces TTS response time by 30 - 50% (0.3 - 0.5 seconds) when the cache is hit. However, for optimal reliability, you may be charged twice for your TTS request.

Bonus: If you request the same TTS text, the cache will be used directly.

## Testing

The unit test has been added.
