### PR TITLE
Use eleven_flash_v2_5 model as the default one

### DIFF
--- a/src/providers/elevenlabs_tts_provider.py
+++ b/src/providers/elevenlabs_tts_provider.py
@@ -95,7 +95,7 @@ class ElevenLabsTTSProvider:
         device_id: Optional[int] = None,
         speaker_name: Optional[str] = None,
         voice_id: Optional[str] = "JBFqnCBsd6RMkjVDRZzb",
-        model_id: Optional[str] = "eleven_multilingual_v2",
+        model_id: Optional[str] = "eleven_flash_v2_5",
         output_format: Optional[str] = "mp3_44100_128",
     ):
         """

--- a/tests/providers/test_elevenlabs_tts_provider copy.py
+++ b/tests/providers/test_elevenlabs_tts_provider copy.py
@@ -75,7 +75,7 @@ def test_add_pending_message(mock_audio_stream):
         {
             "text": "test message",
             "voice_id": "JBFqnCBsd6RMkjVDRZzb",
-            "model_id": "eleven_multilingual_v2",
+            "model_id": "eleven_flash_v2_5",
             "output_format": "mp3_44100_128",
         }
     )


### PR DESCRIPTION
## Overview

`eleven_flash_v2_5` is the ultra fast model with the latency for around 75ms.

## Changes
- Change the default TTS model