### PR TITLE
Support custom kwargs for OpenAI LLMs

### DIFF
--- a/feature/custom-kwargs-for-llms/Modified OpenAILLM Class
+++ b/feature/custom-kwargs-for-llms/Modified OpenAILLM Class
@@ -1,0 +1,70 @@
+import logging
+import time
+import typing as T
+
+import openai
+from pydantic import BaseModel
+
+from llm import LLM, LLMConfig
+
+R = T.TypeVar("R", bound=BaseModel)
+
+class OpenAILLM(LLM[R]):
+    def __init__(
+        self, 
+        output_model: T.Type[R], 
+        config: T.Optional[LLMConfig] = None,
+        **kwargs
+    ):
+        super().__init__(output_model, config)
+
+        base_url = config.base_url or "https://api.openmind.org/api/core/openai"
+
+        if config.api_key is None or config.api_key == "":
+            raise ValueError("config file missing api_key")
+        else:
+            api_key = config.api_key
+
+        client_kwargs = {
+            "base_url": base_url,
+            "api_key": api_key,
+            **kwargs  # Include any additional kwargs for client initialization
+        }
+
+        logging.info(f"Initializing OpenAI client with {client_kwargs}")
+        self._client = openai.AsyncClient(**client_kwargs)
+        self._additional_kwargs = kwargs
+
+    async def ask(self, prompt: str, **kwargs) -> R | None:
+        try:
+            logging.debug(f"OpenAI LLM input: {prompt}")
+            self.io_provider.llm_start_time = time.time()
+            self.io_provider.set_llm_prompt(prompt)
+
+            # Merge default kwargs with provided kwargs
+            completion_kwargs = {
+                "model": "gpt-4o-mini" if self._config.model is None else self._config.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "response_format": self._output_model,
+                **kwargs  # Include any additional kwargs for completion
+            }
+
+            parsed_response = await self._client.beta.chat.completions.parse(
+                **completion_kwargs
+            )
+
+            message_content = parsed_response.choices[0].message.content
+            self.io_provider.llm_end_time = time.time()
+
+            try:
+                parsed_response = self._output_model.model_validate_json(
+                    message_content
+                )
+                logging.debug(f"LLM output: {parsed_response}")
+                return parsed_response
+            except Exception as e:
+                logging.error(f"Error parsing response: {e}")
+                return None
+        except Exception as e:
+            logging.error(f"Error asking LLM: {e}")
+            return None

--- a/feature/custom-kwargs-for-llms/README.md
+++ b/feature/custom-kwargs-for-llms/README.md
@@ -18,7 +18,6 @@ timeout=30, # Custom timeout for client
 max_retries=3 # Custom retry configuration
 )
 
-text
 
 #### Making Requests with Custom Parameters
 
@@ -30,7 +29,6 @@ top_p=0.9, # Nucleus sampling parameter
 max_tokens=100 # Maximum response length
 )
 
-text
 
 ### Supported Parameters
 

--- a/feature/custom-kwargs-for-llms/README.md
+++ b/feature/custom-kwargs-for-llms/README.md
@@ -1,0 +1,58 @@
+# OpenAI LLM Integration
+
+## Custom Kwargs Support
+
+The OpenAILLM class now supports custom keyword arguments (kwargs) for both initialization and request customization. This feature allows you to pass additional parameters to both the OpenAI client initialization and individual API calls.
+
+### Usage Examples
+
+#### Initializing with Custom Kwargs
+
+from your_module import OpenAILLM, LLMConfig
+
+Configure the LLM with custom client parameters
+llm = OpenAILLM(
+output_model=YourResponseModel,
+config=LLMConfig(api_key="your-api-key"),
+timeout=30, # Custom timeout for client
+max_retries=3 # Custom retry configuration
+)
+
+text
+
+#### Making Requests with Custom Parameters
+
+Make a request with custom parameters
+response = await llm.ask(
+prompt="Your prompt here",
+temperature=0.7, # Control randomness
+top_p=0.9, # Nucleus sampling parameter
+max_tokens=100 # Maximum response length
+)
+
+text
+
+### Supported Parameters
+
+#### Client Initialization Parameters
+- `timeout`: Request timeout in seconds
+- `max_retries`: Maximum number of retry attempts
+- Any other parameters supported by the OpenAI AsyncClient
+
+#### Request Parameters
+- `temperature`: Controls randomness (0.0 to 1.0)
+- `top_p`: Nucleus sampling parameter
+- `max_tokens`: Maximum length of generated response
+- `presence_penalty`: Penalty for new tokens based on presence in text
+- `frequency_penalty`: Penalty for new tokens based on frequency in text
+- Any other parameters supported by the OpenAI Chat Completions API
+
+### Error Handling
+
+The implementation includes proper error handling for both invalid parameters and API errors. All errors are logged for debugging purposes.
+
+### Testing
+
+Run the tests using pytest:
+
+pytest test_openai_llm.py -v

--- a/feature/custom-kwargs-for-llms/test_openai_llm.py
+++ b/feature/custom-kwargs-for-llms/test_openai_llm.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import BaseModel
+from unittest.mock import AsyncMock, patch
+from your_module import OpenAILLM, LLMConfig
+
+class TestResponse(BaseModel):
+    text: str
+    confidence: float
+
+@pytest.mark.asyncio
+async def test_openai_llm_with_kwargs():
+    # Test configuration
+    config = LLMConfig(
+        api_key="test-key",
+        base_url="https://test-api.com"
+    )
+
+    # Custom kwargs for testing
+    custom_kwargs = {
+        "timeout": 30,
+        "max_retries": 3
+    }
+
+    # Initialize LLM with custom kwargs
+    llm = OpenAILLM(TestResponse, config, **custom_kwargs)
+
+    # Mock the AsyncClient
+    with patch('openai.AsyncClient') as mock_client:
+        # Setup mock response
+        mock_response = AsyncMock()
+        mock_response.choices = [
+            AsyncMock(
+                message=AsyncMock(
+                    content='{"text": "Test response", "confidence": 0.95}'
+                )
+            )
+        ]
+        
+        mock_client.return_value.beta.chat.completions.parse = AsyncMock(
+            return_value=mock_response
+        )
+
+        # Test ask method with additional kwargs
+        response = await llm.ask(
+            "Test prompt",
+            temperature=0.7,
+            top_p=0.9
+        )
+
+        # Verify the response
+        assert isinstance(response, TestResponse)
+        assert response.text == "Test response"
+        assert response.confidence == 0.95
+
+        # Verify that kwargs were passed correctly
+        mock_client.assert_called_once_with(
+            base_url="https://test-api.com",
+            api_key="test-key",
+            timeout=30,
+            max_retries=3
+        )
+
+@pytest.mark.asyncio
+async def test_openai_llm_invalid_kwargs():
+    config = LLMConfig(api_key="test-key")
+    
+    # Test with invalid kwargs
+    with pytest.raises(ValueError):
+        OpenAILLM(TestResponse, config, invalid_param="invalid")


### PR DESCRIPTION
## Overview
Support custom kwargs for OpenAI LLMs

## Changes
The OpenAILLM class now supports custom keyword arguments (kwargs) for both initialization and request customization. This feature allows you to pass additional parameters to both the OpenAI client initialization and individual API calls.

## Testing
### Error Handling

The implementation includes proper error handling for both invalid parameters and API errors. All errors are logged for debugging purposes.

### Testing

Run the tests using pytest:

pytest test_openai_llm.py -v
## Impact
### Supported Parameters

#### Client Initialization Parameters
- `timeout`: Request timeout in seconds
- `max_retries`: Maximum number of retry attempts
- Any other parameters supported by the OpenAI AsyncClient

#### Request Parameters
- `temperature`: Controls randomness (0.0 to 1.0)
- `top_p`: Nucleus sampling parameter
- `max_tokens`: Maximum length of generated response
- `presence_penalty`: Penalty for new tokens based on presence in text
- `frequency_penalty`: Penalty for new tokens based on frequency in text
- Any other parameters supported by the OpenAI Chat Completions API

## Additional Information
Submitted from UPenn Blockchain Hackathon