### PR TITLE
Use aiohttp for multi-agent

### DIFF
--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -118,14 +118,14 @@ class MultiLLM(LLM[R]):
 
             # Initialize session if needed
             await self._init_session()
-            
+
             async with self.session.post(
                 self.endpoint,
                 json=request,
                 headers=headers,
             ) as response:
                 response_json = await response.json()
-                    
+
             self.io_provider.llm_end_time = time.time()
             logging.info(f"Raw response: {response_json}")
 

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -119,6 +119,7 @@ class MultiLLM(LLM[R]):
             # Initialize session if needed
             await self._init_session()
 
+            response_json = None
             async with self.session.post(
                 self.endpoint,
                 json=request,

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -3,7 +3,7 @@ import logging
 import time
 import typing as T
 
-import requests
+import aiohttp
 from pydantic import BaseModel
 
 from llm import LLM, LLMConfig
@@ -48,6 +48,24 @@ class MultiLLM(LLM[R]):
 
         # Configure the API endpoint
         self.endpoint = "https://api.openmind.org/api/core/agent/robotic_team/runs"
+        self.session = None
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        await self._init_session()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        if self.session:
+            await self.session.close()
+            self.session = None
+
+    async def _init_session(self):
+        """Initialize aiohttp session if it doesn't exist."""
+        if self.session is None:
+            timeout = aiohttp.ClientTimeout(total=60)
+            self.session = aiohttp.ClientSession(timeout=timeout)
 
     async def ask(
         self, prompt: str, messages: T.List[T.Dict[str, str]] = []
@@ -98,13 +116,16 @@ class MultiLLM(LLM[R]):
                 "structured_outputs": True,
             }
 
-            response = requests.post(
+            # Initialize session if needed
+            await self._init_session()
+            
+            async with self.session.post(
                 self.endpoint,
                 json=request,
                 headers=headers,
-            )
-
-            response_json = response.json()
+            ) as response:
+                response_json = await response.json()
+                    
             self.io_provider.llm_end_time = time.time()
             logging.info(f"Raw response: {response_json}")
 
@@ -122,3 +143,9 @@ class MultiLLM(LLM[R]):
         except Exception as e:
             logging.error(f"Error during API request: {str(e)}")
             return None
+
+    async def close(self):
+        """Close the session when done."""
+        if self.session:
+            await self.session.close()
+            self.session = None

--- a/tests/llm/plugins/test_multi_llm.py
+++ b/tests/llm/plugins/test_multi_llm.py
@@ -1,11 +1,12 @@
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock, MagicMock
+import json
 
 import pytest
+import aiohttp
 
 from llm import LLMConfig
 from llm.output_model import CortexOutputModel
 from llm.plugins.multi_llm import MultiLLM
-
 
 @pytest.fixture
 def config():
@@ -27,7 +28,16 @@ def mock_response():
 @pytest.fixture
 def mock_structured_output_response():
     """Mock API response with structured output matching our model"""
-    return {"structured_output": {"result": "This is a structured result"}}
+    return {
+        "structured_output": json.dumps({
+            "commands": [
+                {"type": "move", "value": "wag tail"},
+                {"type": "move", "value": "walk"},
+                {"type": "speak", "value": "Hello!"},
+                {"type": "emotion", "value": "happy"}
+            ]
+        })
+    }
 
 
 @pytest.fixture
@@ -35,18 +45,49 @@ def llm(config):
     return MultiLLM(CortexOutputModel, config)
 
 
+@pytest.fixture
+def mocked_session(request):
+    """Provides a mocked aiohttp ClientSession with configurable post response."""
+    # Get parameter from parametrize. Can be data directly or a fixture name string
+    param = getattr(request, "param", {})
+
+    if isinstance(param, str):
+        # If it's a string, assume it's a fixture name and resolve it
+        response_data = request.getfixturevalue(param)
+    else:
+        # Otherwise, assume it's the data itself (like in test_ask_invalid_response)
+        response_data = param
+
+    mock_context_manager = AsyncMock()
+    mock_response_obj = AsyncMock()
+    mock_response_obj.json = AsyncMock(return_value=response_data)
+    mock_response_obj.status = 200 # Default status
+    mock_context_manager.__aenter__.return_value = mock_response_obj
+
+    mock_session = AsyncMock(spec=aiohttp.ClientSession)
+    mock_session.post.return_value = mock_context_manager
+    mock_session.close = AsyncMock()
+
+    return mock_session
+
+
 def test_init_with_config(llm, config):
     """Test initialization with provided configuration"""
     assert llm._config.api_key == config.api_key
     assert llm.endpoint == "https://api.openmind.org/api/core/agent/robotic_team/runs"
     assert llm._config.model == config.model
+    assert llm.session is None
 
 
-def test_init_with_default_model():
+@pytest.mark.asyncio
+async def test_init_with_default_model():
     """Test that the MultiLLM uses the default model when not specified"""
     config = LLMConfig(api_key="test_key")
     llm = MultiLLM(CortexOutputModel, config)
+
     assert llm._config.model == "gemini-2.0-flash"
+
+    await llm.close()
 
 
 def test_init_empty_key():
@@ -57,46 +98,52 @@ def test_init_empty_key():
 
 
 @pytest.mark.asyncio
-async def test_ask_structured_output(llm, mock_response):
-    """Test handling of content-only response format"""
-    with patch("requests.post") as mock_post:
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = mock_response
+async def test_context_manager():
+    """Test async context manager functionality"""
+    config = LLMConfig(api_key="test_key", model="test-model")
+    
+    async with MultiLLM(CortexOutputModel, config) as llm:
+        assert llm.session is not None
+        assert isinstance(llm.session, aiohttp.ClientSession)
+    
+    assert llm.session is None
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mocked_session", ["mock_response"], indirect=True)
+async def test_ask_structured_output(llm, mocked_session):
+    """Test handling of structured output response format"""
+    with patch('aiohttp.ClientSession', return_value=mocked_session):
         result = await llm.ask("test prompt")
+
         assert result is not None
+        assert isinstance(result, CortexOutputModel)
 
 
 @pytest.mark.asyncio
 async def test_ask_api_error(llm):
     """Test handling of API errors"""
-    with patch("requests.post") as mock_post:
-        mock_post.return_value.status_code = 500
-        mock_post.return_value.text = "Internal Server Error"
+    # Configure mock session to raise an error on post
+    mock_session = AsyncMock(spec=aiohttp.ClientSession)
+    mock_context_manager = AsyncMock()
+    mock_context_manager.__aenter__.side_effect = aiohttp.ClientError("API Error")
+    mock_session.post.return_value = mock_context_manager
+    mock_session.close = AsyncMock()
 
+    with patch('aiohttp.ClientSession', return_value=mock_session):
         result = await llm.ask("test prompt")
         assert result is None
 
 
 @pytest.mark.asyncio
-async def test_ask_invalid_response(llm):
-    """Test handling of invalid response format"""
-    with patch("requests.post") as mock_post:
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = {"invalid": "response"}
-
-        result = await llm.ask("test prompt")
-        assert result is None
-
-
-@pytest.mark.asyncio
-async def test_io_provider_timing(llm, mock_structured_output_response):
+@pytest.mark.parametrize("mocked_session", ["mock_structured_output_response"], indirect=True)
+async def test_io_provider_timing(llm, mocked_session):
     """Test timing metrics collection"""
-    with patch("requests.post") as mock_post:
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = mock_structured_output_response
+    # The fixture sets up the response using mock_structured_output_response name
+    with patch('aiohttp.ClientSession', return_value=mocked_session):
+        result = await llm.ask("test prompt")
 
-        await llm.ask("test prompt")
+        assert result is not None 
         assert llm.io_provider.llm_start_time is not None
         assert llm.io_provider.llm_end_time is not None
         assert llm.io_provider.llm_end_time >= llm.io_provider.llm_start_time

--- a/tests/llm/plugins/test_multi_llm.py
+++ b/tests/llm/plugins/test_multi_llm.py
@@ -42,6 +42,7 @@ def mock_structured_output_response():
         )
     }
 
+
 @pytest.fixture
 def llm(config):
     return MultiLLM(CortexOutputModel, config)


### PR DESCRIPTION
## Overview
Enhencement requested in https://github.com/OpenmindAGI/OM1/issues/204

## Changes
Created session management when initiating the LLM, used aiohttp to make the API calls.

## Testing
Updated unit tests, performed manual test and the multi-agent endpoint is working fine (we are having some JSON parsing issue, which is not related to this code change)

## Impact
The implementation should improve performance by allowing async API calls. I'm not feeling the improved API call rate when performing manual testing. Additional changes might be needed.

## Additional Information
N/A
