### PR TITLE
Add output conversion to the output model

### DIFF
--- a/src/llm/output_model.py
+++ b/src/llm/output_model.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, Field
+from typing import Any, Dict
+
+from pydantic import BaseModel, Field, model_validator
 
 
 class Command(BaseModel):
@@ -15,6 +17,24 @@ class Command(BaseModel):
 
     type: str = Field(..., description="The type of action")
     value: str = Field(..., description="The action argument")
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_command_format(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Validates and transforms the input data.
+        If data is a dict with a single key-value pair (e.g., {"move": "wag tail"}),
+        it will be transformed to {"type": "move", "value": "wag tail"}.
+        """
+        if (
+            isinstance(data, dict)
+            and len(data) == 1
+            and "type" not in data
+            and "value" not in data
+        ):
+            key, value = next(iter(data.items()))
+            return {"type": key, "value": value}
+        return data
 
 
 class CortexOutputModel(BaseModel):


### PR DESCRIPTION
## Overview
Fix structured output for ChatGPT models

## Changes
We were having output model validation issue.
```
ERROR:root:Error validating structured response: 6 validation errors for CortexOutputModel
commands.0.type
  Field required [type=missing, input_value={'move': 'wag tail'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
commands.0.value
  Field required [type=missing, input_value={'move': 'wag tail'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
commands.1.type
  Field required [type=missing, input_value={'speak': 'Woof! Hi there!'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
commands.1.value
  Field required [type=missing, input_value={'speak': 'Woof! Hi there!'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
commands.2.type
  Field required [type=missing, input_value={'emotion': 'joy'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
commands.2.value
  Field required [type=missing, input_value={'emotion': 'joy'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
WARNING:root:No output from LLM
```

This was because the ChatGPT models are not able to correctly understand the JSON schema.
Prompt:
```
      Here are the properties for each field:                                                                                                                       
      <json_field_properties>                                                                                                                                       
      {                                                                                                                                                             
        "commands": {                                                                                                                                               
          "description": "List of actions to execute",                                                                                                              
          "items": {                                                                                                                                                
            "$ref": "#/$defs/Command"                                                                                                                               
          },                                                                                                                                                        
          "type": "array"                                                                                                                                           
        },                                                                                                                                                          
        "$defs": {                                                                                                                                                  
          "Command": {                                                                                                                                              
            "type": {                                                                                                                                               
              "description": "The type of action",                                                                                                                  
              "type": "string"                                                                                                                                      
            },                                                                                                                                                      
            "value": {                                                                                                                                              
              "description": "The action argument",                                                                                                                 
              "type": "string"                                                                                                                                      
            }                                                                                                                                                       
          }                                                                                                                                                         
        }                                                                                                                                                           
      }                                                                                                                                                             
      </json_field_properties>                                                                                                                                      
      Start your response with `{` and end it with `}`.                                                                                                             
      Your output will be passed to json.loads() to convert it to a Python object.                                                                                  
      Make sure it only contains valid JSON.  
```

Output:
```
{                                                                                                                                                             
        "commands": [                                                                                                                                               
          {                                                                                                                                                         
            "move": "wag tail"                                                                                                                                      
          },                                                                                                                                                        
          {                                                                                                                                                         
            "speak": "Woof! Hello there!"                                                                                                                           
          },                                                                                                                                                        
          {                                                                                                                                                         
            "emotion": "joy"                                                                                                                                        
          }                                                                                                                                                         
        ]                                                                                                                                                           
      }  
```

The prompt was generated by Agno and we don't have a good way to improve it yet. I also tried renaming the Command entries (like command_action_type to avoid confusion), but that didn't help.

The easiest solution is to add a conversion when the result is returned as a `type`: `value`

## Testing
Verified in local API

```
INFO:root:Raw response: {'content': '{\n  "commands": [\n    {\n      "move": "wag tail"\n    },\n    {\n      "speak": "Woof! Hello there!"\n    },\n    {\n      "emotion": "joy"\n    }\n  ]\n}', 'model': 'gpt-4o-mini', 'usage': {'completion_tokens': [50, 50], 'completion_tokens_details': [{'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}], 'input_tokens': [2075, 2029], 'output_tokens': [50, 50], 'prompt_tokens': [2075, 2029], 'prompt_tokens_details': [{'audio_tokens': 0, 'cached_tokens': 1408}, {'audio_tokens': 0, 'cached_tokens': 0}], 'time': [1.554867040948011, 1.1129232499515638], 'total_tokens': [2125, 2079]}}
INFO:root:Inputs and LLM Outputs: {'current_action': 'wag tail', 'last_speech': 'Woof! Hello there!', 'current_emotion': 'joy', 'system_latency': {'fuse_time': 0.3405478000640869, 'llm_start': 0.34055399894714355, 'processing': 3.5885777473449707, 'complete': 3.9291317462921143}, 'inputs': [{'input_type': 'Object Detector', 'timestamp': 0.0, 'input': 'You see a person on your right. You also see a tv.'}]}
INFO:root:SendThisToROS2: {'move': 'wag tail'}
INFO:root:SendThisToROS2: {'speak': 'Woof! Hello there!'}
INFO:root:SendThisToROS2: {'face': 'joy'}
```

## Impact
Should fix multi-agent endpoint usage in OM1
