### PR TITLE
Split multiagent inputs

### DIFF
--- a/.github/workflows/unitest.yml
+++ b/.github/workflows/unitest.yml
@@ -60,4 +60,4 @@ jobs:
         if: always()
         with:
           name: test-results-${{ runner.os }}
-          path: pytest-results/
+          path: pytest-cache/

--- a/.github/workflows/unitest.yml
+++ b/.github/workflows/unitest.yml
@@ -60,4 +60,4 @@ jobs:
         if: always()
         with:
           name: test-results-${{ runner.os }}
-          path: pytest-cache/
+          path: ./pytest-cache/

--- a/.github/workflows/unitest.yml
+++ b/.github/workflows/unitest.yml
@@ -60,4 +60,4 @@ jobs:
         if: always()
         with:
           name: test-results-${{ runner.os }}
-          path: .pytest-cache/
+          path: .pytest_cache/

--- a/.github/workflows/unitest.yml
+++ b/.github/workflows/unitest.yml
@@ -60,4 +60,4 @@ jobs:
         if: always()
         with:
           name: test-results-${{ runner.os }}
-          path: ./pytest-cache/
+          path: .pytest-cache/

--- a/src/fuser/__init__.py
+++ b/src/fuser/__init__.py
@@ -105,6 +105,13 @@ class Fuser:
 
         logging.debug(f"FINAL PROMPT: {fused_prompt}")
 
+        # Record the global prompt, actions and inputs
+        self.io_provider.set_fuser_system_prompt(f"{system_prompt}")
+        self.io_provider.set_fuser_inputs(inputs_fused)
+        self.io_provider.set_fuser_available_actions(
+            f"AVAILABLE ACTIONS:\n{actions_fused}\n\n{question_prompt}"
+        )
+
         # Record the timestamp of the output
         self.io_provider.fuser_end_time = time.time()
 

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -47,9 +47,6 @@ class MultiLLM(LLM[R]):
 
         # Configure the API endpoint
         self.endpoint = "https://api.openmind.org/api/core/agent"
-        self.session = None
-
-        self.session = None
 
     async def ask(
         self, prompt: str, messages: T.List[T.Dict[str, str]] = []

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -71,8 +71,6 @@ class MultiLLM(LLM[R]):
             parsing fails.
         """
         try:
-            logging.debug(f"MultiLLM input: {prompt}")
-
             self.io_provider.llm_start_time = time.time()
             self.io_provider.set_llm_prompt(prompt)
 
@@ -81,11 +79,17 @@ class MultiLLM(LLM[R]):
                 "Content-Type": "application/json",
             }
             request = {
-                "message": prompt,
+                "system_prompt": self.io_provider.fuser_system_prompt,
+                "inputs": self.io_provider.fuser_inputs,
+                "available_actions": self.io_provider.fuser_available_actions,
                 "model": self._config.model,
                 "response_format": self._output_model.model_json_schema(),
                 "structured_outputs": True,
             }
+
+            logging.debug(f"MultiLLM system_prompt: {request["system_prompt"]}")
+            logging.debug(f"MultiLLM inputs: {request["inputs"]}")
+            logging.debug(f"MultiLLM available_actions: {request["available_actions"]}")
 
             response = requests.post(
                 self.endpoint,

--- a/src/providers/io_provider.py
+++ b/src/providers/io_provider.py
@@ -36,10 +36,16 @@ class IOProvider:
         Initialize the IOProvider with thread lock and empty storage.
         """
         self._lock: threading.Lock = threading.Lock()
+
         self._inputs: Dict[str, str] = {}
         self._input_timestamps: Dict[str, float] = {}
+
+        self._fuser_system_prompt: Optional[str] = None
+        self._fuser_inputs: Optional[str] = None
+        self._fuser_available_actions: Optional[str] = None
         self._fuser_start_time: Optional[float] = None
         self._fuser_end_time: Optional[float] = None
+
         self._llm_prompt: Optional[str] = None
         self._llm_start_time: Optional[float] = None
         self._llm_end_time: Optional[float] = None
@@ -128,6 +134,75 @@ class IOProvider:
         """
         with self._lock:
             return self._input_timestamps.get(key)
+
+    @property
+    def fuser_system_prompt(self) -> Optional[str]:
+        """
+        Get the fuser system prompt.
+        """
+        with self._lock:
+            return self._fuser_system_prompt
+
+    @fuser_system_prompt.setter
+    def fuser_system_prompt(self, value: Optional[str]) -> None:
+        """
+        Set the fuser system prompt.
+        """
+        with self._lock:
+            self._fuser_system_prompt = value
+
+    def set_fuser_system_prompt(self, value: Optional[str]) -> None:
+        """
+        Alternative method to set fuser system prompt.
+        """
+        with self._lock:
+            self._fuser_system_prompt = value
+
+    @property
+    def fuser_inputs(self) -> Optional[str]:
+        """
+        Get the fuser inputs.
+        """
+        with self._lock:
+            return self._fuser_inputs
+
+    @fuser_inputs.setter
+    def fuser_inputs(self, value: Optional[str]) -> None:
+        """
+        Set the fuser inputs.
+        """
+        with self._lock:
+            self._fuser_inputs = value
+
+    def set_fuser_inputs(self, value: Optional[str]) -> None:
+        """
+        Alternative method to set fuser inputs.
+        """
+        with self._lock:
+            self._fuser_inputs = value
+
+    @property
+    def fuser_available_actions(self) -> Optional[str]:
+        """
+        Get the fuser available actions.
+        """
+        with self._lock:
+            return self._fuser_available_actions
+
+    @fuser_available_actions.setter
+    def fuser_available_actions(self, value: Optional[str]) -> None:
+        """
+        set the fuser available actions.
+        """
+        with self._lock:
+            self._fuser_available_actions = value
+
+    def set_fuser_available_actions(self, value: Optional[str]) -> None:
+        """
+        Alternative method to set fuser available actions.
+        """
+        with self._lock:
+            self._fuser_available_actions = value
 
     @property
     def fuser_start_time(self) -> Optional[float]:


### PR DESCRIPTION
## Overview
This PR splits the prompt input into three parts: `system_prompt`, `inputs`, and `available_actions`.
This helps the `/agent` endpoint format the messages more effectively.