### PR TITLE
rag endpoint in multi llm

### DIFF
--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -50,7 +50,7 @@ class MultiLLM(LLM[R]):
         self.rag_endpoint = "https://api.openmind.org/api/core/rag/query"
         
         # Flag to enable/disable RAG functionality
-        self.use_rag = config.get("use_rag", False)
+        self.use_rag = hasattr(config, "use_rag") and config.use_rag
 
     async def ask(
         self, prompt: str, messages: T.List[T.Dict[str, str]] = []

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -104,8 +104,6 @@ class MultiLLM(LLM[R]):
                 except Exception as e:
                     logging.error(f"Error querying RAG endpoint: {str(e)}")
             
-            augmented_prompt = f"{rag_context}{prompt}" if rag_context else prompt
-            
             request = {
                 "system_prompt": self.io_provider.fuser_system_prompt,
                 "inputs": self.io_provider.fuser_inputs,

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -47,7 +47,7 @@ class MultiLLM(LLM[R]):
 
         self.endpoint = "https://api.openmind.org/api/core/agent"
         self.rag_endpoint = "https://api.openmind.org/api/core/rag/query"
-        
+
         self.use_rag = hasattr(config, "use_rag") and config.use_rag
 
     async def ask(
@@ -82,28 +82,29 @@ class MultiLLM(LLM[R]):
             rag_context = ""
             if self.use_rag:
                 try:
-                    rag_request = {
-                        "query": prompt,
-                        "skip_cache": False
-                    }
-                    
+                    rag_request = {"query": prompt, "skip_cache": False}
+
                     rag_response = requests.post(
                         self.rag_endpoint,
                         json=rag_request,
                         headers=headers,
                     )
-                    
+
                     if rag_response.status_code == 200:
                         rag_data = rag_response.json()
                         if rag_data.get("success") and "data" in rag_data:
                             rag_content = rag_data["data"].get("content", "")
                             if rag_content:
-                                rag_context = f"[Knowledge Base Context]: {rag_content}\n\n"
-                                logging.debug(f"RAG context added: {rag_context[:100]}...")
-                
+                                rag_context = (
+                                    f"[Knowledge Base Context]: {rag_content}\n\n"
+                                )
+                                logging.debug(
+                                    f"RAG context added: {rag_context[:100]}..."
+                                )
+
                 except Exception as e:
                     logging.error(f"Error querying RAG endpoint: {str(e)}")
-            
+
             request = {
                 "system_prompt": self.io_provider.fuser_system_prompt,
                 "inputs": self.io_provider.fuser_inputs,
@@ -112,11 +113,13 @@ class MultiLLM(LLM[R]):
                 "response_format": self._output_model.model_json_schema(),
                 "structured_outputs": True,
             }
-            
+
             if rag_context:
                 rag_instruction = f"The following information from the user's knowledge base is relevant to the query:\n\n{rag_context}\n\nUse this information to provide a more accurate and contextually relevant response."
                 if request["system_prompt"]:
-                    request["system_prompt"] = f"{request['system_prompt']}\n\n{rag_instruction}"
+                    request["system_prompt"] = (
+                        f"{request['system_prompt']}\n\n{rag_instruction}"
+                    )
                 else:
                     request["system_prompt"] = rag_instruction
 

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -116,12 +116,9 @@ class MultiLLM(LLM[R]):
 
             if rag_context:
                 rag_instruction = f"The following information from the user's knowledge base is relevant to the query:\n\n{rag_context}\n\nUse this information to provide a more accurate and contextually relevant response."
-                if request["system_prompt"]:
-                    request["system_prompt"] = (
-                        f"{request['system_prompt']}\n\n{rag_instruction}"
-                    )
-                else:
-                    request["system_prompt"] = rag_instruction
+                request["system_prompt"] = (
+                    f"{request['system_prompt']}\n\n{rag_instruction}"
+                )
 
             logging.debug(f"MultiLLM system_prompt: {request['system_prompt']}")
             logging.debug(f"MultiLLM inputs: {request['inputs']}")


### PR DESCRIPTION
### TL;DR

Added RAG (Retrieval-Augmented Generation) functionality to the MultiLLM plugin.

### What changed?

- Added a new RAG endpoint URL for knowledge base queries
- Implemented a `use_rag` flag that can be enabled via configuration
- Created a workflow that queries the knowledge base before sending the main prompt
- Added logic to augment prompts with retrieved context when RAG is enabled
- Modified system prompts to include instructions for using RAG context
- Added error handling for RAG queries to gracefully continue without context if needed

