### PR TITLE
Fix gamepad

### DIFF
--- a/src/actions/move_game_controller/connector/go2_game_controller.py
+++ b/src/actions/move_game_controller/connector/go2_game_controller.py
@@ -113,8 +113,8 @@ class Go2GameControllerConnector(ActionConnector[IDLEInput]):
         self.RTLT_moving = False
 
         # Movement speed m/s and rad/s (?)
-        self.move_speed = 0.5
-        self.turn_speed = 0.8
+        self.move_speed = 0.3
+        self.turn_speed = 0.4
 
         self.odom = OdomProvider()
         logging.info(f"Game controller Odom Provider: {self.odom}")
@@ -228,7 +228,6 @@ class Go2GameControllerConnector(ActionConnector[IDLEInput]):
 
         if self.gamepad:
             # try to read USB data, and if there is nothing, timeout
-            # data = list(self.gamepad.read(64, timeout=50))
             data = list(self.gamepad.read(64, timeout=50))
 
         if data and len(data) > 0:
@@ -298,8 +297,6 @@ class Go2GameControllerConnector(ActionConnector[IDLEInput]):
                 # we WERE moving, but we just let go of one or both triggers
                 move_triggered_RTLT = True
                 logging.debug("Triggers released - Stopping rotation")
-                if self.sport_client:
-                    self.sport_client.StopMove()
 
             # Update previous Trigger values
             self.rt_previous = rt
@@ -327,17 +324,15 @@ class Go2GameControllerConnector(ActionConnector[IDLEInput]):
             elif self.d_pad_value == 7:  # Left
                 logging.info("D-pad LEFT - Moving left")
                 move_triggered_dpad = True
-                self._move_robot(0.0, self.turn_speed)
+                self._move_robot(0.0, self.move_speed)
             elif self.d_pad_value == 3:  # Right
                 logging.info("D-pad RIGHT - Moving right")
                 move_triggered_dpad = True
-                self._move_robot(0.0, -self.turn_speed)
+                self._move_robot(0.0, -self.move_speed)
             elif self.d_pad_previous > 0 and self.d_pad_value == 0:
                 # Usewr just released DPAD
                 logging.debug("D-pad released - Stopping movement")
                 move_triggered_dpad = True
-                if self.sport_client:
-                    self.sport_client.StopMove()
 
             # update the value of d_pad_previous
             self.d_pad_previous = self.d_pad_value


### PR DESCRIPTION
The `self.sport_client.StopMove()` method is not `asynchronous` (it’s not a `CallNoReply`), so it blocks the next gamepad reading for 10 seconds. Using `self._move(0.0, 0.0)` allows the robot to move in small increments which is not smooth.
Based on my testing, gamepad has 1-2 seconds latency no matter what.